### PR TITLE
fix(alerts): show metric units in dropdown labels and threshold label

### DIFF
--- a/web/src/routes/(settings)/alerts/+page.svelte
+++ b/web/src/routes/(settings)/alerts/+page.svelte
@@ -294,7 +294,7 @@
 										{#each Array.from(alertVars
 												.filter((v) => v.cat === selectedCategory)
 												.filter((v) => v.resrc === selectedResource)) as alertVar (alertVar.var)}
-											<option value={alertVar.var}>{types2names[alertVar.var]}</option>
+											<option value={alertVar.var}>{types2names[alertVar.var]} ({var2unit[alertVar.var]})</option>
 										{/each}
 									</select>
 								</div>
@@ -303,7 +303,7 @@
 									<label for="category">Property</label>
 									<select id="category" bind:value={selectedProperty} required>
 										{#each Array.from(alertVars.filter((v) => v.cat === selectedCategory)) as alertVar (alertVar.var)}
-											<option value={alertVar.var}>{types2names[alertVar.var]}</option>
+											<option value={alertVar.var}>{types2names[alertVar.var]} ({var2unit[alertVar.var]})</option>
 										{/each}
 									</select>
 								</div>
@@ -320,8 +320,8 @@
 							<div class="form-group">
 								<label for="threshold"
 									>Threshold
-									{#if alertForm.var.var && var2unit[alertForm.var.var]}
-										({var2unit[alertForm.var.var]})
+									{#if selectedProperty && var2unit[selectedProperty]}
+										({var2unit[selectedProperty]})
 									{/if}
 								</label>
 								<input


### PR DESCRIPTION
This fixes the "Add alert" screen to properly display the units of the selected metric. Previously, the user only saw the metric name in the dropdown, and the threshold label didn't update dynamically on new forms.

**Changes made:**
- **Dropdown Options:** Updated both the `Resource Name` and `Category` (system) property dropdowns to show the unit in parentheses alongside the metric name (e.g., `CPU Usage (%)`). This prevents user confusion when entering threshold values before selecting the metric.
- **Threshold Label:** Fixed the conditional check that displays the unit next to the input field. It now correctly checks `selectedProperty` instead of the initially empty `alertForm.var.var`, ensuring the unit appears immediately upon selecting a metric for both **new** and **existing** alerts.

> [!NOTE]
> I have _not_ tested this locally and this was an AI-assisted change, but I'm hoping it's the right change - please let me know if anything needs to be changed, and thanks for your work on this project!
