### PR TITLE
fix(auth): Ensure password is properly encoded.

### DIFF
--- a/web/static/auth.html
+++ b/web/static/auth.html
@@ -208,7 +208,7 @@
 						headers: {
 							'Content-Type': 'application/x-www-form-urlencoded'
 						},
-						body: 'password=' + password
+            body: new URLSearchParams({ password }).toString()
 					});
 
 					if (res.status === 200) {


### PR DESCRIPTION
application/x-www-form-urlencoded reserves the chars ```+, &, % and =```

When building the request, auth.html passes raw user input without any encoding.  If the user has a reserved character in their password this will corrupt the request, resulting in a failed authentication with a correct password.